### PR TITLE
Use connection state in conversation view

### DIFF
--- a/android-application/src/main/java/com/inkapplications/ack/android/capture/CaptureEvents.kt
+++ b/android-application/src/main/java/com/inkapplications/ack/android/capture/CaptureEvents.kt
@@ -56,7 +56,9 @@ class CaptureEvents @Inject constructor(
     private val connectionEnabled = mutableConnectionState.map { it != ConnectionState.Disconnected }.distinctUntilChanged()
     private val mutableLocationTransmitState = MutableStateFlow(false)
 
-    private val currentDriver = readSettings.observeData(connectionSettings.driver)
+    val driverSelection = readSettings.observeData(connectionSettings.driver)
+
+    private val currentDriver = driverSelection
         .map {
             when (it) {
                 DriverSelection.Audio -> drivers.afskDriver

--- a/android-application/src/main/java/com/inkapplications/ack/android/capture/CaptureScreen.kt
+++ b/android-application/src/main/java/com/inkapplications/ack/android/capture/CaptureScreen.kt
@@ -93,15 +93,18 @@ private fun CaptureBottomBar(
     navController: NavHostController,
 ) {
     BottomAppBar(
-        backgroundColor = AckTheme.colors.surface,
+        backgroundColor = AckTheme.colors.background,
         contentColor = contentColorFor(AckTheme.colors.surface),
         cutoutShape = RoundedCornerShape(50),
+        contentPadding = PaddingValues(0.dp),
+        modifier = Modifier.fillMaxWidth(),
     ) {
+        val currentRoute = navController.currentBackStackEntryAsState().value?.destination?.route
         BottomNavigation(
             backgroundColor = AckTheme.colors.surface,
             contentColor = contentColorFor(AckTheme.colors.surface),
+            modifier = Modifier.fillMaxWidth()
         ) {
-            val currentRoute = navController.currentBackStackEntryAsState().value?.destination?.route
             BottomNavigationItem(
                 icon = { Icon(Icons.Default.Map, contentDescription = null) },
                 label = { Text(stringResource(R.string.menu_capture_map), softWrap = false) },

--- a/android-application/src/main/java/com/inkapplications/ack/android/capture/messages/conversation/ConversationScreen.kt
+++ b/android-application/src/main/java/com/inkapplications/ack/android/capture/messages/conversation/ConversationScreen.kt
@@ -1,5 +1,6 @@
 package com.inkapplications.ack.android.capture.messages.conversation
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -31,7 +32,9 @@ fun ConversationScreen(
 ) = AckScreen {
     Column {
         val viewState = viewModel.conversationState.collectAsState().value
-        TopAppBar {
+        TopAppBar(
+            elevation = 1.dp,
+        ) {
             IconButton(
                 onClick = controller::onNavigateUpPressed,
             ) {
@@ -56,34 +59,43 @@ fun ConversationScreen(
         }
         Surface(
             shape = AckTheme.shapes.corners,
+            color = AckTheme.colors.surface,
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(AckTheme.spacing.gutter),
         ) {
-            Row(
-               verticalAlignment = Alignment.CenterVertically,
-            ) {
-                val textFieldValue = remember { mutableStateOf("") }
-                OutlinedTextField(
-                    value = textFieldValue.value,
-                    onValueChange = { textFieldValue.value = it },
-                    singleLine = true,
-                    placeholder = { Text(stringResource(R.string.messages_conversation_send_placeholder)) },
-                    colors = TextFieldDefaults.outlinedTextFieldColors(
-                        backgroundColor = Color.Transparent,
-                        focusedBorderColor = Color.Transparent,
-                        unfocusedBorderColor = Color.Transparent,
-                        disabledBorderColor = Color.Transparent,
-                    ),
-                    modifier = Modifier.weight(1f),
+            Column {
+                Text(
+                    text = viewState.connectionText,
+                    style = AckTheme.typography.caption,
+                    modifier = Modifier.align(Alignment.CenterHorizontally).padding(top = AckTheme.spacing.item)
                 )
-                IconButton(
-                    onClick = {
-                        controller.onSendMessage(textFieldValue.value)
-                        textFieldValue.value = ""
-                    },
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    Icon(Icons.Default.Send, stringResource(R.string.messages_conversation_send_action))
+                    val textFieldValue = remember { mutableStateOf("") }
+                    OutlinedTextField(
+                        value = textFieldValue.value,
+                        onValueChange = { textFieldValue.value = it },
+                        singleLine = true,
+                        placeholder = { Text(stringResource(R.string.messages_conversation_send_placeholder)) },
+                        colors = TextFieldDefaults.outlinedTextFieldColors(
+                            backgroundColor = Color.Transparent,
+                            focusedBorderColor = Color.Transparent,
+                            unfocusedBorderColor = Color.Transparent,
+                            disabledBorderColor = Color.Transparent,
+                        ),
+                        modifier = Modifier.weight(1f),
+                    )
+                    IconButton(
+                        onClick = {
+                            controller.onSendMessage(textFieldValue.value)
+                            textFieldValue.value = ""
+                        },
+                        enabled = viewState.sendEnabled,
+                    ) {
+                        Icon(Icons.Default.Send, stringResource(R.string.messages_conversation_send_action))
+                    }
                 }
             }
         }

--- a/android-application/src/main/java/com/inkapplications/ack/android/capture/messages/conversation/ConversationViewModel.kt
+++ b/android-application/src/main/java/com/inkapplications/ack/android/capture/messages/conversation/ConversationViewModel.kt
@@ -3,11 +3,12 @@ package com.inkapplications.ack.android.capture.messages.conversation
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.inkapplications.ack.android.capture.CaptureEvents
 import com.inkapplications.ack.android.capture.messages.MessageEvents
 import com.inkapplications.ack.structures.station.Callsign
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import javax.inject.Inject
 
@@ -19,13 +20,18 @@ import javax.inject.Inject
 class ConversationViewModel @Inject constructor(
     savedState: SavedStateHandle,
     messageEvents: MessageEvents,
+    captureEvents: CaptureEvents,
     conversationViewStateFactory: ConversationViewStateFactory,
 ): ViewModel() {
     private val conversationAddress = savedState.get<String>(EXTRA_ADDRESS)?.let(::Callsign)!!
 
-    val conversationState = messageEvents.conversationList(conversationAddress)
-        .map { conversationViewStateFactory.createMessageList(conversationAddress, it) }
-        .stateIn(viewModelScope, SharingStarted.Eagerly, conversationViewStateFactory.createInitial(conversationAddress))
+    val conversationState = combine(
+        messageEvents.conversationList(conversationAddress),
+        captureEvents.driverSelection,
+        captureEvents.connectionState
+    ) { messages, driverSelection, connected ->
+        conversationViewStateFactory.createMessageList(conversationAddress, messages, connected, driverSelection)
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, conversationViewStateFactory.createInitial(conversationAddress))
 }
 
 

--- a/android-application/src/main/java/com/inkapplications/ack/android/capture/messages/conversation/ConversationViewState.kt
+++ b/android-application/src/main/java/com/inkapplications/ack/android/capture/messages/conversation/ConversationViewState.kt
@@ -10,14 +10,33 @@ sealed interface ConversationViewState {
     val title: String
 
     /**
+     * Whether the send button in the message form should be clickable.
+     */
+    val sendEnabled: Boolean
+
+    /**
+     * Text displayed above the message field to signify the connection status.
+     */
+    val connectionText: String
+
+    /**
      * Indicates that no data has been loaded yet.
      */
-    data class Initial(override val title: String): ConversationViewState
+    data class Initial(
+        override val title: String,
+        override val connectionText: String,
+    ): ConversationViewState {
+        override val sendEnabled: Boolean = false
+    }
 
     /**
      * Indicates that data has been loaded, but there are no messages yet.
      */
-    data class Empty(override val title: String): ConversationViewState
+    data class Empty(
+        override val title: String,
+        override val sendEnabled: Boolean,
+        override val connectionText: String,
+    ): ConversationViewState
 
     /**
      * Message data for the conversation.
@@ -27,5 +46,7 @@ sealed interface ConversationViewState {
     data class MessageList(
         override val title: String,
         val messages: List<MessageItemState>,
+        override val sendEnabled: Boolean,
+        override val connectionText: String,
     ): ConversationViewState
 }

--- a/android-application/src/main/java/com/inkapplications/ack/android/capture/messages/conversation/ConversationViewStateFactory.kt
+++ b/android-application/src/main/java/com/inkapplications/ack/android/capture/messages/conversation/ConversationViewStateFactory.kt
@@ -7,7 +7,10 @@ import androidx.compose.material.icons.filled.SettingsInputAntenna
 import androidx.compose.material.icons.filled.Storage
 import androidx.compose.ui.Alignment
 import com.inkapplications.ack.android.R
+import com.inkapplications.ack.android.capture.ConnectionState
 import com.inkapplications.ack.android.capture.messages.MessageData
+import com.inkapplications.ack.android.connection.DriverSelection
+import com.inkapplications.ack.android.connection.readableName
 import com.inkapplications.ack.data.PacketSource
 import com.inkapplications.ack.structures.PacketData
 import com.inkapplications.ack.structures.station.Callsign
@@ -32,6 +35,7 @@ class ConversationViewStateFactory @Inject constructor(
     fun createInitial(adressee: Callsign): ConversationViewState {
         return ConversationViewState.Initial(
             title = createTitle(adressee),
+            connectionText = stringResources.getString(R.string.messages_conversation_disconnected)
         )
     }
 
@@ -43,17 +47,27 @@ class ConversationViewStateFactory @Inject constructor(
      */
     fun createMessageList(
         addressee: Callsign,
-        messages: List<MessageData>
+        messages: List<MessageData>,
+        connectionState: ConnectionState,
+        driverSelection: DriverSelection,
     ): ConversationViewState {
         val title = createTitle(addressee)
+        val connectionText = when (connectionState) {
+            ConnectionState.Connected -> stringResources.getString(R.string.messages_conversation_connected, stringResources.getString(driverSelection.readableName))
+            ConnectionState.Connecting, ConnectionState.Disconnected -> stringResources.getString(R.string.messages_conversation_disconnected)
+        }
 
         return when {
             messages.isEmpty() -> ConversationViewState.Empty(
-                title = title
+                title = title,
+                sendEnabled = connectionState == ConnectionState.Connected,
+                connectionText = connectionText,
             )
             else -> ConversationViewState.MessageList(
                 title = title,
                 messages = messages.map { createMessageView(it) },
+                sendEnabled = connectionState == ConnectionState.Connected,
+                connectionText = connectionText,
             )
         }
     }

--- a/android-application/src/main/java/com/inkapplications/ack/android/map/MapScreen.kt
+++ b/android-application/src/main/java/com/inkapplications/ack/android/map/MapScreen.kt
@@ -46,7 +46,9 @@ fun MapScreen(
         }
     }
     Box(
-        modifier = Modifier.fillMaxSize().padding(bottom = bottomContentProtection),
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(bottom = bottomContentProtection),
         contentAlignment = Alignment.BottomEnd,
     ) {
         LocationStateButton(state.trackPosition, onEnableLocation, onDisableLocation)

--- a/android-application/src/main/java/com/inkapplications/ack/android/ui/theme/AckTheme.kt
+++ b/android-application/src/main/java/com/inkapplications/ack/android/ui/theme/AckTheme.kt
@@ -42,8 +42,8 @@ object AckTheme {
         @ReadOnlyComposable
         get() = darkColors.copy(
             foreground = ColorPalette.darkStroke,
-            background = ColorPalette.lightStrokeSoftened,
-            surface = ColorPalette.lightStroke,
+            background = ColorPalette.lightStroke,
+            surface = ColorPalette.lightStrokeSoftened,
             warnForeground = ColorPalette.darkWarning,
             dangerForeground = ColorPalette.red,
         )

--- a/android-application/src/main/java/com/inkapplications/ack/android/ui/theme/ColorVariant.kt
+++ b/android-application/src/main/java/com/inkapplications/ack/android/ui/theme/ColorVariant.kt
@@ -24,7 +24,7 @@ data class ColorVariant(
         secondary = accent,
         secondaryVariant = accent,
         background = background,
-        surface = surface,
+        surface = background,
         error = error,
         onPrimary = onAccent,
         onSecondary = onAccent,

--- a/android-application/src/main/res/values/capture.xml
+++ b/android-application/src/main/res/values/capture.xml
@@ -9,8 +9,8 @@
     <string name="capture_controls_expand_action">Controls</string>
     <string name="capture_controls_collapse_action">Close</string>
     <string name="capture_controls_connection_type_unknown">Unknown</string>
-    <string name="capture_controls_connection_off">Receive Off</string>
-    <string name="capture_controls_connection_on">Receiving</string>
+    <string name="capture_controls_connection_off">Not Connected</string>
+    <string name="capture_controls_connection_on">Connected</string>
     <string name="capture_controls_position_off">Position Disabled</string>
     <string name="capture_controls_position_on">Position Enabled</string>
     <string name="capture_controls_settings_name">Settings</string>

--- a/android-application/src/main/res/values/messages.xml
+++ b/android-application/src/main/res/values/messages.xml
@@ -3,6 +3,8 @@
     <string name="messages_conversation_send_placeholder">Text Message</string>
     <string name="messages_conversation_empty">No messages yet.</string>
     <string name="messages_conversation_send_action">Send</string>
+    <string name="messages_conversation_disconnected">Disconnected</string>
+    <string name="messages_conversation_connected">Connected to: %s</string>
     <string name="messages_compose_action">Compose Message</string>
     <string name="messages_create_title">New Message</string>
     <string name="messages_create_field_callsign_label">Callsign</string>

--- a/android-application/src/test/java/com/inkapplications/ack/android/capture/messages/conversation/ConversationViewStateFactoryTest.kt
+++ b/android-application/src/test/java/com/inkapplications/ack/android/capture/messages/conversation/ConversationViewStateFactoryTest.kt
@@ -6,7 +6,9 @@ import androidx.compose.material.icons.filled.SettingsInputAntenna
 import androidx.compose.material.icons.filled.Storage
 import androidx.compose.ui.Alignment
 import com.inkapplications.ack.android.*
+import com.inkapplications.ack.android.capture.ConnectionState
 import com.inkapplications.ack.android.capture.messages.MessageData
+import com.inkapplications.ack.android.connection.DriverSelection
 import com.inkapplications.ack.data.CapturedPacket
 import com.inkapplications.ack.data.PacketSource
 import com.inkapplications.ack.structures.PacketData
@@ -31,10 +33,17 @@ class ConversationViewStateFactoryTest {
 
     @Test
     fun emptyMessageList() {
-        val result = factory.createMessageList(addressee.callsign, emptyList())
+        val result = factory.createMessageList(addressee.callsign, emptyList(), ConnectionState.Disconnected, DriverSelection.Audio)
 
         assertTrue(result is ConversationViewState.Empty)
         assertEquals("KE0YOF", result.title)
+        assertEquals(false, result.sendEnabled)
+    }
+
+    @Test
+    fun connected() {
+        val result = factory.createMessageList(addressee.callsign, emptyList(), ConnectionState.Connected, DriverSelection.Audio)
+        assertEquals(true, result.sendEnabled)
     }
 
     @Test
@@ -78,7 +87,7 @@ class ConversationViewStateFactoryTest {
 
     private fun getMessageState(packet: CapturedPacket): MessageItemState {
         val data = MessageData(me.callsign, packet)
-        val result = factory.createMessageList(addressee.callsign, listOf(data))
+        val result = factory.createMessageList(addressee.callsign, listOf(data), ConnectionState.Disconnected, DriverSelection.Audio)
 
         assertTrue(result is ConversationViewState.MessageList)
         assertEquals(1, result.messages.size)

--- a/aprs-android/src/main/java/com/inkapplications/ack/data/drivers/PacketDrivers.kt
+++ b/aprs-android/src/main/java/com/inkapplications/ack/data/drivers/PacketDrivers.kt
@@ -1,15 +1,7 @@
 package com.inkapplications.ack.data.drivers
 
-import com.inkapplications.ack.structures.AprsPacket
-import com.inkapplications.ack.structures.EncodingConfig
-
 class PacketDrivers(
     val internetDriver: InternetDriver,
     val afskDriver: AfskDriver,
     val tncDriver: TncDriver,
-) {
-    suspend fun transmitAll(packet: AprsPacket, encodingConfig: EncodingConfig) {
-        internetDriver.transmitPacket(packet, encodingConfig)
-        afskDriver.transmitPacket(packet, encodingConfig)
-    }
-}
+)


### PR DESCRIPTION
Uses the connection state to control the send button in the Messages/conversation view and adds connection state above the messages to signify why the user may be unable to send a message.