### PR TITLE
Make all compose objects stable.

### DIFF
--- a/android-application/build.gradle.kts
+++ b/android-application/build.gradle.kts
@@ -67,7 +67,13 @@ android {
     }
     kotlinOptions {
         jvmTarget = "1.8"
+        freeCompilerArgs += listOf(
+            "-P",
+            "plugin:androidx.compose.compiler.plugins.kotlin:stabilityConfigurationPath=" +
+             "${project.projectDir.absolutePath}/compose_compiler_config.conf"
+        )
     }
+
     composeOptions {
         kotlinCompilerExtensionVersion = androidLibraries.versions.compose.compiler.get()
     }

--- a/android-application/compose_compiler_config.conf
+++ b/android-application/compose_compiler_config.conf
@@ -1,0 +1,2 @@
+// Consider everything stable
+**.*


### PR DESCRIPTION
I do not want to be dealing with what compose does and doesn't infer as stable. Just treat everything as stable, all data classes used by this application should not be mutable in anyway already and I have no plans to allow such a pattern in the app.