### PR TITLE
Use release name when archiving bundle assets for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,8 +42,8 @@ jobs:
                 run: |
                     mkdir -p build
                     mkdir -p build/output
-                    cp android-application/build/outputs/apk/functional/release/android-application-functional-release.apk build/output/Ack-${{ github.sha }}.apk
-                    cp android-application/build/outputs/bundle/functionalRelease/android-application-functional-release.aab build/output/Ack-${{ github.sha }}.aab
+                    cp android-application/build/outputs/apk/functional/release/android-application-functional-release.apk build/output/Ack-${{ github.ref_name }}.apk
+                    cp android-application/build/outputs/bundle/functionalRelease/android-application-functional-release.aab build/output/Ack-${{ github.ref_name }}.aab
             -
                 name: Archive APK
                 uses: actions/upload-artifact@v4.6.2


### PR DESCRIPTION
This is causing the release build to fail -- looks like this was changed to allow uploading the snapshot bundles as a git SHA, but shouldn't have been changed for the release bundle