### PR TITLE
Make play releases optional

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,7 @@ jobs:
             -
                 name: Deploy to Play Store
                 uses: r0adkll/upload-google-play@v1.0.15
+                continue-on-error: true
                 with:
                     serviceAccountJson: service_account.json
                     packageName: com.inkapplications.ack.android


### PR DESCRIPTION
These are currently failing the build, but can be uploaded separately and should not fail the tag release